### PR TITLE
`iter-mut` is implemented.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-fixed-vec"
-version = "0.4.6"
+version = "1.0.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient fixed capacity vector with pinned elements."
@@ -10,8 +10,7 @@ keywords = ["vec", "pinned", "array", "split", "fixed"]
 categories = ["data-structures"]
 
 [dependencies]
-orx-pinned-vec = "0.5"
-
+orx-pinned-vec = "1.0"
 
 [[bench]]
 name = "random_access"

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -5,6 +5,7 @@ use std::fmt::{Debug, Formatter, Result};
 
 impl<T> PinnedVec<T> for FixedVec<T> {
     type Iter<'a> = std::slice::Iter<'a, T> where T: 'a, Self: 'a;
+    type IterMut<'a> = std::slice::IterMut<'a, T> where T: 'a, Self: 'a;
 
     /// Returns the index of the `element` with the given reference.
     /// This method has *O(1)* time complexity.
@@ -189,6 +190,11 @@ impl<T> PinnedVec<T> for FixedVec<T> {
     #[inline(always)]
     fn iter(&self) -> Self::Iter<'_> {
         self.data.iter()
+    }
+
+    #[inline(always)]
+    fn iter_mut(&mut self) -> Self::IterMut<'_> {
+        self.data.iter_mut()
     }
 }
 
@@ -467,6 +473,27 @@ mod tests {
 
         test(FixedVec::new(53));
         test(FixedVec::new(1000));
+    }
+
+    #[test]
+    fn iter_iter_mut() {
+        let mut vec = FixedVec::new(4);
+        vec.push('a');
+        vec.push('b');
+
+        let mut iter = vec.iter();
+        assert_eq!(Some(&'a'), iter.next());
+        assert_eq!(Some(&'b'), iter.next());
+        assert_eq!(None, iter.next());
+
+        for x in vec.iter_mut() {
+            *x = 'x';
+        }
+
+        let mut iter = vec.iter();
+        assert_eq!(Some(&'x'), iter.next());
+        assert_eq!(Some(&'x'), iter.next());
+        assert_eq!(None, iter.next());
     }
 
     #[derive(Debug, PartialEq, Clone)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,2 +1,2 @@
 pub use crate::FixedVec;
-pub use orx_pinned_vec::{NotSelfRefVecItem, PinnedVec, PinnedVecSimple, SelfRefVecItem};
+pub use orx_pinned_vec::{NotSelfRefVecItem, PinnedVec, PinnedVecSimple};


### PR DESCRIPTION
Also updated the dependency of `PinnedVec` to orx_pinned_vec version 1.0 which finalizes the definigion of `orx_pinned_vec::self_referential_elements` module.