### PR TITLE
major pinned-vec refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-fixed-vec"
-version = "1.0.2"
+version = "2.0.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with fixed capacity and pinned elements."
@@ -10,7 +10,7 @@ keywords = ["vec", "pinned", "array", "split", "fixed"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pinned-vec = "1.0"
+orx-pinned-vec = "2.0"
 
 [[bench]]
 name = "random_access"

--- a/src/common_traits/clone.rs
+++ b/src/common_traits/clone.rs
@@ -1,0 +1,12 @@
+use crate::FixedVec;
+
+impl<T> Clone for FixedVec<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        let mut data = Vec::with_capacity(self.data.capacity());
+        data.extend_from_slice(&self.data);
+        Self { data }
+    }
+}

--- a/src/common_traits/debug.rs
+++ b/src/common_traits/debug.rs
@@ -1,5 +1,4 @@
 use crate::FixedVec;
-use orx_pinned_vec::PinnedVec;
 use std::fmt::Debug;
 
 impl<T> Debug for FixedVec<T>
@@ -7,7 +6,9 @@ where
     T: Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        <Self as PinnedVec<T>>::debug(self, f)
+        f.debug_struct("FixedVec")
+            .field("data", &self.data)
+            .finish()
     }
 }
 
@@ -23,6 +24,6 @@ mod tests {
         }
 
         let debug_str = format!("{:?}", vec);
-        assert_eq!("FixedVec [0, 1, 2, 3]\n", debug_str);
+        assert_eq!("FixedVec { data: [0, 1, 2, 3] }", debug_str);
     }
 }

--- a/src/common_traits/eq.rs
+++ b/src/common_traits/eq.rs
@@ -1,5 +1,4 @@
 use crate::FixedVec;
-use orx_pinned_vec::PinnedVec;
 
 impl<T, U> PartialEq<U> for FixedVec<T>
 where
@@ -7,7 +6,7 @@ where
     T: PartialEq,
 {
     fn eq(&self, other: &U) -> bool {
-        <Self as PinnedVec<T>>::partial_eq(self, other.as_ref())
+        self.data.as_slice() == other.as_ref()
     }
 }
 

--- a/src/common_traits/mod.rs
+++ b/src/common_traits/mod.rs
@@ -1,4 +1,5 @@
 mod as_ref;
+mod clone;
 mod debug;
 mod eq;
 mod index;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,2 +1,2 @@
 pub use crate::FixedVec;
-pub use orx_pinned_vec::{NotSelfRefVecItem, PinnedVec, PinnedVecSimple};
+pub use orx_pinned_vec::PinnedVec;


### PR DESCRIPTION
* `FixedVec` implements "orx_pinned_vec::PinnedVec" version 2.0.
  * pinned elements guarantee is formalized and documented,
  * unsafe methods such as `clone` or `insert` are now safe. pinned vector on its own cannot build inter-element references; hence, these methods are not unsafe. this responsibility is passed to the struct enabling these references, namely, orx_selfref_col.
  * in addition to being a marker trait, this crate now provides `test_pinned_vec` function which is essential in asserting that a pinned vector implementation satisfies the required guarantees.
* `Clone` is implemented.
* `Debug` is implemented.