### PR TITLE
FixedVec is extended by try_grow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-fixed-vec"
-version = "2.3.0"
+version = "2.4.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with fixed capacity and pinned elements."
@@ -10,7 +10,7 @@ keywords = ["vec", "pinned", "array", "split", "fixed"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pinned-vec = "2.3"
+orx-pinned-vec = "2.4"
 
 [[bench]]
 name = "random_access"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,4 +129,4 @@ mod fixed_vec;
 mod pinned_vec;
 
 pub use fixed_vec::FixedVec;
-pub use orx_pinned_vec::PinnedVec;
+pub use orx_pinned_vec::{PinnedVec, PinnedVecGrowthError};


### PR DESCRIPTION
try_grow to increase the capacity of the pinned vector with default additional amount defined by the specific implementation. It is not guaranteed that the pinned vector will succeed while keeping the elements pinned to their locations; and hence, will return a result.

Currently FixedVec cannot grow and returns the error.