### PR TITLE
`grow_to` is implemented

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-fixed-vec"
-version = "2.4.0"
+version = "2.5.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with fixed capacity and pinned elements."
@@ -10,7 +10,7 @@ keywords = ["vec", "pinned", "array", "split", "fixed"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pinned-vec = "2.4"
+orx-pinned-vec = "2.5"
 
 [[bench]]
 name = "random_access"


### PR DESCRIPTION
As fixed vector cannot grow, it is responsible for returning `Ok` when there is sufficient capacity or the correct `Err` otherwise..