### PR TITLE
Support for Concurrency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-fixed-vec"
-version = "2.5.0"
+version = "2.6.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with fixed capacity and pinned elements."
@@ -10,7 +10,7 @@ keywords = ["vec", "pinned", "array", "split", "fixed"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pinned-vec = "2.5"
+orx-pinned-vec = "2.6"
 
 [[bench]]
 name = "random_access"

--- a/README.md
+++ b/README.md
@@ -9,11 +9,9 @@ An efficient constant access time vector with fixed capacity and pinned elements
 
 There are various situations where pinned elements are necessary.
 
-* It is critical in enabling **efficient, convenient and safe self-referential collections** with thin references, see [`SelfRefCol`](https://crates.io/crates/orx-selfref-col) for details.
-* It is essential in allowing an **immutable push** vector; i.e., [`ImpVec`](https://crates.io/crates/orx-imp-vec). This is a very useful operation when the desired collection is a bag or a container of things, rather than having a collective meaning. In such cases, `ImpVec` avoids heap allocations and wide pointers such as `Box` or `Rc` or etc.
-* It is important for **async** code; following [blog](https://blog.cloudflare.com/pin-and-unpin-in-rust) could be useful for the interested.
-
-*As explained in [rust-docs](https://doc.rust-lang.org/std/pin/index.html), there exist `Pin` and `Unpin` types for similar purposes. However, the solution is complicated and low level using `PhantomPinned`, `NonNull`, `dangling`, `Box::pin`, pointer accesses, etc.*
+* It is critical in enabling **efficient, convenient and safe self-referential collections** with thin references, see [`SelfRefCol`](https://crates.io/crates/orx-selfref-col) for details, and its special cases such as [`LinkedList`](https://crates.io/crates/orx-linked-list).
+* It is essential in allowing an **immutable push** vector; i.e., [`ImpVec`](https://crates.io/crates/orx-imp-vec). This is a very useful operation when the desired collection is a bag or a container of things, rather than having a collective meaning. In such cases, `ImpVec` allows avoiding certain borrow checker complexities, heap allocations and wide pointers such as `Box` or `Rc` or etc.
+* It is important for **concurrent** programs since it eliminates safety concerns related with elements implicitly carried to different memory locations. This helps reducing and dealing with the complexity of concurrency. [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) is a very simplistic and efficient concurrent data structure built on top of pinned vector guarantees.
 
 ## B. Comparison with `SplitVec`
 
@@ -21,7 +19,7 @@ There are various situations where pinned elements are necessary.
 
 | **`FixedVec`**                                                               | **`SplitVec`**                                                                   |
 |------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-| Implements `PinnedVec` => can be wrapped by an `ImpVec` or `SelfRefCol`.     | Implements `PinnedVec` => can be wrapped by an `ImpVec` or `SelfRefCol`.         |
+| Implements `PinnedVec` => can be wrapped by an `ImpVec` or `SelfRefCol` or `ConcurrentBag`. | Implements `PinnedVec` => can as well be wrapped by them.         |
 | Requires exact capacity to be known while creating.                          | Can be created with any level of prior information about required capacity.      |
 | Cannot grow beyond capacity; panics when `push` is called at capacity.       | Can grow dynamically. Further, it provides control on how it must grow. |
 | It is just a wrapper around `std::vec::Vec`; hence, has equivalent performance. | Performance-optimized built-in growth strategies also have `std::vec::Vec` equivalent performance. |
@@ -35,7 +33,7 @@ After the performance optimizations on the `SplitVec`, it is now comparable to `
 Most common `std::vec::Vec` operations are available in `FixedVec` with the same signature.
 
 ```rust
-use orx_fixed_vec::*;
+use orx_fixed_vec::prelude::*;
 
 // capacity is not optional
 let mut vec = FixedVec::new(4);
@@ -71,7 +69,7 @@ assert_eq!(&std_vec, &[0, 1, 2, 3]);
 Unless elements are removed from the vector, the memory location of an element already pushed to the `SplitVec` <ins>never</ins> changes unless explicitly changed.
 
 ```rust
-use orx_fixed_vec::*;
+use orx_fixed_vec::prelude::*;
 
 let mut vec = FixedVec::new(100);
 

--- a/benches/grow.rs
+++ b/benches/grow.rs
@@ -2,7 +2,7 @@ use criterion::{
     black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId,
     Criterion,
 };
-use orx_fixed_vec::*;
+use orx_fixed_vec::prelude::*;
 
 fn get_value<const N: usize>(i: usize) -> [u64; N] {
     let modulo = i % 3;

--- a/benches/random_access.rs
+++ b/benches/random_access.rs
@@ -2,7 +2,7 @@ use criterion::{
     black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId,
     Criterion,
 };
-use orx_fixed_vec::*;
+use orx_fixed_vec::prelude::*;
 use rand::*;
 use rand_chacha::ChaCha8Rng;
 

--- a/benches/serial_access.rs
+++ b/benches/serial_access.rs
@@ -2,7 +2,7 @@ use criterion::{
     black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId,
     Criterion,
 };
-use orx_fixed_vec::*;
+use orx_fixed_vec::prelude::*;
 
 fn get_value<const N: usize>(i: usize) -> [u64; N] {
     let modulo = i % 3;

--- a/src/common_traits/as_ref.rs
+++ b/src/common_traits/as_ref.rs
@@ -22,7 +22,7 @@ impl<T> Deref for FixedVec<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::*;
+    use crate::prelude::*;
     use std::ops::Deref;
 
     #[test]

--- a/src/common_traits/debug.rs
+++ b/src/common_traits/debug.rs
@@ -14,7 +14,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::*;
+    use crate::prelude::*;
 
     #[test]
     fn debug() {

--- a/src/common_traits/eq.rs
+++ b/src/common_traits/eq.rs
@@ -12,7 +12,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::*;
+    use crate::prelude::*;
 
     #[test]
     fn eq() {

--- a/src/common_traits/from_iter.rs
+++ b/src/common_traits/from_iter.rs
@@ -9,7 +9,7 @@ impl<T> FromIterator<T> for FixedVec<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::*;
+    use crate::prelude::*;
 
     #[test]
     fn from_iter() {

--- a/src/common_traits/index.rs
+++ b/src/common_traits/index.rs
@@ -25,7 +25,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::*;
+    use crate::prelude::*;
 
     #[test]
     fn index() {

--- a/src/common_traits/into_iter.rs
+++ b/src/common_traits/into_iter.rs
@@ -12,7 +12,7 @@ impl<T> IntoIterator for FixedVec<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::*;
+    use crate::prelude::*;
 
     #[test]
     fn into_iter() {

--- a/src/fixed_vec.rs
+++ b/src/fixed_vec.rs
@@ -24,7 +24,7 @@ impl<T> FixedVec<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use orx_fixed_vec::*;
+    /// use orx_fixed_vec::prelude::*;
     ///
     /// let mut vec = FixedVec::new(7);
     /// vec.push(42);
@@ -43,7 +43,7 @@ impl<T> FixedVec<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use orx_fixed_vec::*;
+    /// use orx_fixed_vec::prelude::*;
     ///
     /// let mut vec = FixedVec::new(7);
     /// vec.push(42);
@@ -62,7 +62,7 @@ impl<T> FixedVec<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use orx_fixed_vec::*;
+    /// use orx_fixed_vec::prelude::*;
     ///
     /// let mut vec = FixedVec::new(2);
     /// assert!(!vec.is_full());
@@ -120,7 +120,7 @@ const ERR_MSG_OUT_OF_ROOM: &str =
 
 #[cfg(test)]
 mod tests {
-    use crate::*;
+    use crate::prelude::*;
 
     #[test]
     fn new() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,9 @@
 //!
 //! There are various situations where pinned elements are necessary.
 //!
-//! * It is critical in enabling **efficient, convenient and safe self-referential collections** with thin references, see [`SelfRefCol`](https://crates.io/crates/orx-selfref-col) for details.
-//! * It is essential in allowing an **immutable push** vector; i.e., [`ImpVec`](https://crates.io/crates/orx-imp-vec). This is a very useful operation when the desired collection is a bag or a container of things, rather than having a collective meaning. In such cases, `ImpVec` avoids heap allocations and wide pointers such as `Box` or `Rc` or etc.
-//! * It is important for **async** code; following [blog](https://blog.cloudflare.com/pin-and-unpin-in-rust) could be useful for the interested.
-//!
-//! *As explained in [rust-docs](https://doc.rust-lang.org/std/pin/index.html), there exist `Pin` and `Unpin` types for similar purposes. However, the solution is complicated and low level using `PhantomPinned`, `NonNull`, `dangling`, `Box::pin`, pointer accesses, etc.*
+//! * It is critical in enabling **efficient, convenient and safe self-referential collections** with thin references, see [`SelfRefCol`](https://crates.io/crates/orx-selfref-col) for details, and its special cases such as [`LinkedList`](https://crates.io/crates/orx-linked-list).
+//! * It is essential in allowing an **immutable push** vector; i.e., [`ImpVec`](https://crates.io/crates/orx-imp-vec). This is a very useful operation when the desired collection is a bag or a container of things, rather than having a collective meaning. In such cases, `ImpVec` allows avoiding certain borrow checker complexities, heap allocations and wide pointers such as `Box` or `Rc` or etc.
+//! * It is important for **concurrent** programs since it eliminates safety concerns related with elements implicitly carried to different memory locations. This helps reducing and dealing with the complexity of concurrency. [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) is a very simplistic and efficient concurrent data structure built on top of pinned vector guarantees.
 //!
 //! ## B. Comparison with `SplitVec`
 //!
@@ -21,7 +19,7 @@
 //!
 //! | **`FixedVec`**                                                               | **`SplitVec`**                                                                   |
 //! |------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-//! | Implements `PinnedVec` => can be wrapped by an `ImpVec` or `SelfRefCol`.     | Implements `PinnedVec` => can be wrapped by an `ImpVec` or `SelfRefCol`.         |
+//! | Implements `PinnedVec` => can be wrapped by an `ImpVec` or `SelfRefCol` or `ConcurrentBag`. | Implements `PinnedVec` => can as well be wrapped by them.         |
 //! | Requires exact capacity to be known while creating.                          | Can be created with any level of prior information about required capacity.      |
 //! | Cannot grow beyond capacity; panics when `push` is called at capacity.       | Can grow dynamically. Further, it provides control on how it must grow. |
 //! | It is just a wrapper around `std::vec::Vec`; hence, has equivalent performance. | Performance-optimized built-in growth strategies also have `std::vec::Vec` equivalent performance. |
@@ -35,7 +33,7 @@
 //! Most common `std::vec::Vec` operations are available in `FixedVec` with the same signature.
 //!
 //! ```rust
-//! use orx_fixed_vec::*;
+//! use orx_fixed_vec::prelude::*;
 //!
 //! // capacity is not optional
 //! let mut vec = FixedVec::new(4);
@@ -71,7 +69,7 @@
 //! Unless elements are removed from the vector, the memory location of an element already pushed to the `SplitVec` <ins>never</ins> changes unless explicitly changed.
 //!
 //! ```rust
-//! use orx_fixed_vec::*;
+//! use orx_fixed_vec::prelude::*;
 //!
 //! let mut vec = FixedVec::new(100);
 //!
@@ -128,5 +126,7 @@ mod common_traits;
 mod fixed_vec;
 mod pinned_vec;
 
+/// Common relevant traits, structs, enums.
+pub mod prelude;
+
 pub use fixed_vec::FixedVec;
-pub use orx_pinned_vec::{PinnedVec, PinnedVecGrowthError};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,2 @@
+pub use crate::FixedVec;
+pub use orx_pinned_vec::{CapacityState, PinnedVec, PinnedVecGrowthError};


### PR DESCRIPTION
* `concurrently_grow_to` method is implemented.
* Returned back to `prelude` approach to include `PinnedVec` dependencies.
* Capacity related tests are extended.