### PR TITLE
`zero_memory` argument in grow_to methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-fixed-vec"
-version = "2.6.1"
+version = "2.7.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with fixed capacity and pinned elements."
@@ -10,7 +10,7 @@ keywords = ["vec", "pinned", "array", "split", "fixed"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pinned-vec = "2.6"
+orx-pinned-vec = "2.7"
 
 [[bench]]
 name = "random_access"


### PR DESCRIPTION
Implementation of the updated grow-to methods in orx-pinned-vec:2.7.