### PR TITLE
`try_reserve_maximum_concurrent_capacity` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-fixed-vec"
-version = "2.7.0"
+version = "2.8.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with fixed capacity and pinned elements."
@@ -10,7 +10,7 @@ keywords = ["vec", "pinned", "array", "split", "fixed"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pinned-vec = "2.7"
+orx-pinned-vec = "2.8"
 
 [[bench]]
 name = "random_access"


### PR DESCRIPTION
`try_reserve_maximum_concurrent_capacity` method is defined which is essential for concurrent wrappers such as [`PinnedConcurrentCol`](https://crates.io/crates/orx-pinned-concurrent-col).