### PR TITLE
IntoIterator is required for PinnedVec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-fixed-vec"
-version = "2.8.0"
+version = "2.9.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with fixed capacity and pinned elements."
@@ -10,7 +10,7 @@ keywords = ["vec", "pinned", "array", "split", "fixed"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pinned-vec = "2.8"
+orx-pinned-vec = "2.9"
 
 [[bench]]
 name = "random_access"

--- a/src/fixed_vec.rs
+++ b/src/fixed_vec.rs
@@ -86,23 +86,22 @@ impl<T> FixedVec<T> {
 
     // helpers
     #[inline(always)]
-    #[allow(clippy::panic)]
     pub(crate) fn panic_if_not_enough_room_for(&self, num_new_items: usize) {
-        if self.data.len() + num_new_items > self.data.capacity() {
-            panic!("{}", ERR_MSG_OUT_OF_ROOM);
-        }
+        assert!(
+            self.data.len() + num_new_items <= self.data.capacity(),
+            "{}",
+            ERR_MSG_OUT_OF_ROOM
+        );
     }
 
     #[inline(always)]
-    #[allow(clippy::panic)]
     pub(crate) fn push_or_panic(&mut self, value: T) {
-        let len = self.data.len();
-        if len == self.data.capacity() {
-            panic!("{}", ERR_MSG_OUT_OF_ROOM);
-        } else {
-            *unsafe { self.data.get_unchecked_mut(len) } = value;
-            unsafe { self.data.set_len(len + 1) };
-        }
+        assert!(
+            self.data.len() < self.data.capacity(),
+            "{}",
+            ERR_MSG_OUT_OF_ROOM
+        );
+        self.data.push(value);
     }
 }
 impl<T> From<Vec<T>> for FixedVec<T> {


### PR DESCRIPTION
* Upgraded the orx-pinned-vec dependency to version 2.9 which requires all pinned vectors to implement `IntoIterator`.
* Further, assertions in `push_or_panic` and `panic_if_not_enough_room_for` methods are cleaned up.