### PR TITLE
`binary_search_by` is implemented

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-fixed-vec"
-version = "2.9.0"
+version = "2.10.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with fixed capacity and pinned elements."
@@ -10,7 +10,7 @@ keywords = ["vec", "pinned", "array", "split", "fixed"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pinned-vec = "2.9"
+orx-pinned-vec = "2.10"
 
 [[bench]]
 name = "random_access"

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -249,6 +249,13 @@ impl<T> PinnedVec<T> for FixedVec<T> {
         self.data.set_len(new_len)
     }
 
+    fn binary_search_by<F>(&self, f: F) -> Result<usize, usize>
+    where
+        F: FnMut(&T) -> Ordering,
+    {
+        self.data.binary_search_by(f)
+    }
+
     fn try_grow(&mut self) -> Result<usize, PinnedVecGrowthError> {
         match self.len() {
             len if len == self.capacity() => {


### PR DESCRIPTION
* Default implementations of `binary_search` and `binary_search_by_key` are provided.
* Extended pinned vector tests are used, including binary search test methods.