### PR TITLE
slices and initialized grow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-fixed-vec"
-version = "2.10.0"
+version = "2.11.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with fixed capacity and pinned elements."
@@ -10,7 +10,7 @@ keywords = ["vec", "pinned", "array", "split", "fixed"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pinned-vec = "2.10"
+orx-pinned-vec = "2.11"
 
 [[bench]]
 name = "random_access"

--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@
 [![orx-fixed-vec crate](https://img.shields.io/crates/v/orx-fixed-vec.svg)](https://crates.io/crates/orx-fixed-vec)
 [![orx-fixed-vec documentation](https://docs.rs/orx-fixed-vec/badge.svg)](https://docs.rs/orx-fixed-vec)
 
-An efficient constant access time vector with fixed capacity and pinned elements. 
+An efficient constant access time vector with fixed capacity and pinned elements.
 
 ## A. Motivation
 
-There are various situations where pinned elements are necessary.
+There are various situations where pinned elements are critical.
 
 * It is critical in enabling **efficient, convenient and safe self-referential collections** with thin references, see [`SelfRefCol`](https://crates.io/crates/orx-selfref-col) for details, and its special cases such as [`LinkedList`](https://crates.io/crates/orx-linked-list).
+* It is important for **concurrent** programs as it eliminates safety concerns related with elements implicitly carried to different memory locations. This helps reducing and dealing with the complexity of concurrency, and leads to efficient concurrent data structures. See [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter), [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) or [`ConcurrentOrderedBag`](https://crates.io/crates/orx-concurrent-ordered-bag) for such concurrent data structures which are conveniently built on the pinned element guarantees of pinned vectors.
 * It is essential in allowing an **immutable push** vector; i.e., [`ImpVec`](https://crates.io/crates/orx-imp-vec). This is a very useful operation when the desired collection is a bag or a container of things, rather than having a collective meaning. In such cases, `ImpVec` allows avoiding certain borrow checker complexities, heap allocations and wide pointers such as `Box` or `Rc` or etc.
-* It is important for **concurrent** programs since it eliminates safety concerns related with elements implicitly carried to different memory locations. This helps reducing and dealing with the complexity of concurrency. [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) is a very simplistic and efficient concurrent data structure built on top of pinned vector guarantees.
 
 ## B. Comparison with `SplitVec`
 
@@ -19,7 +19,7 @@ There are various situations where pinned elements are necessary.
 
 | **`FixedVec`**                                                               | **`SplitVec`**                                                                   |
 |------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-| Implements `PinnedVec` => can be wrapped by an `ImpVec` or `SelfRefCol` or `ConcurrentBag`. | Implements `PinnedVec` => can as well be wrapped by them.         |
+| Implements `PinnedVec` => can be wrapped by an `ImpVec` or `SelfRefCol` or `ConcurrentBag`, etc. | Implements `PinnedVec` => can as well be wrapped by them.         |
 | Requires exact capacity to be known while creating.                          | Can be created with any level of prior information about required capacity.      |
 | Cannot grow beyond capacity; panics when `push` is called at capacity.       | Can grow dynamically. Further, it provides control on how it must grow. |
 | It is just a wrapper around `std::vec::Vec`; hence, has equivalent performance. | Performance-optimized built-in growth strategies also have `std::vec::Vec` equivalent performance. |

--- a/src/fixed_vec.rs
+++ b/src/fixed_vec.rs
@@ -37,6 +37,28 @@ impl<T> FixedVec<T> {
         }
     }
 
+    /// Returns the fixed vector into inner standard vector.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_fixed_vec::prelude::*;
+    ///
+    /// let mut fixed_vec = FixedVec::new(64);
+    /// fixed_vec.push('a');
+    /// fixed_vec.push('b');
+    /// assert_eq!(fixed_vec.as_slice(), &['a', 'b']);
+    ///
+    /// let vec = fixed_vec.into_inner();
+    /// assert_eq!(vec.as_slice(), &['a', 'b']);
+    ///
+    /// let fixed_vec: FixedVec<_> = vec.into();
+    /// assert_eq!(fixed_vec.as_slice(), &['a', 'b']);
+    /// ```
+    pub fn into_inner(self) -> Vec<T> {
+        self.data
+    }
+
     /// Returns the available room for new items; i.e.,
     /// `capacity() - len()`.
     ///
@@ -104,16 +126,19 @@ impl<T> FixedVec<T> {
         self.data.push(value);
     }
 }
+
 impl<T> From<Vec<T>> for FixedVec<T> {
     fn from(value: Vec<T>) -> Self {
         Self { data: value }
     }
 }
+
 impl<T> From<FixedVec<T>> for Vec<T> {
     fn from(value: FixedVec<T>) -> Self {
         value.data
     }
 }
+
 const ERR_MSG_OUT_OF_ROOM: &str =
     "FixedVec is full, a fixed capacity vector cannot exceed its initial capacity.";
 

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,0 +1,1 @@
+pub mod range;

--- a/src/helpers/range.rs
+++ b/src/helpers/range.rs
@@ -1,0 +1,43 @@
+use std::ops::RangeBounds;
+
+pub(crate) fn range_start<R: RangeBounds<usize>>(range: &R) -> usize {
+    match range.start_bound() {
+        std::ops::Bound::Excluded(x) => x + 1,
+        std::ops::Bound::Included(x) => *x,
+        std::ops::Bound::Unbounded => 0,
+    }
+}
+pub(crate) fn range_end<R: RangeBounds<usize>>(range: &R, vec_len: usize) -> usize {
+    match range.end_bound() {
+        std::ops::Bound::Excluded(x) => *x,
+        std::ops::Bound::Included(x) => x + 1,
+        std::ops::Bound::Unbounded => vec_len,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::FixedVec;
+    use orx_pinned_vec::PinnedVec;
+
+    #[test]
+    fn range_start_end() {
+        fn test(vec: FixedVec<usize>) {
+            assert_eq!(10, range_start(&(10..20)));
+            assert_eq!(10, range_start(&(10..=20)));
+            assert_eq!(0, range_start(&(..20)));
+            assert_eq!(10, range_start(&(10..)));
+            assert_eq!(0, range_start(&(..)));
+
+            assert_eq!(20, range_end(&(10..20), vec.len()));
+            assert_eq!(21, range_end(&(10..=20), vec.len()));
+            assert_eq!(20, range_end(&(..20), vec.len()));
+            assert_eq!(vec.len(), range_end(&(10..), vec.len()));
+            assert_eq!(vec.len(), range_end(&(..), vec.len()));
+        }
+
+        test(FixedVec::new(100));
+        test(FixedVec::new(20));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,11 @@
 //!
 //! ## A. Motivation
 //!
-//! There are various situations where pinned elements are necessary.
+//! There are various situations where pinned elements are critical.
 //!
 //! * It is critical in enabling **efficient, convenient and safe self-referential collections** with thin references, see [`SelfRefCol`](https://crates.io/crates/orx-selfref-col) for details, and its special cases such as [`LinkedList`](https://crates.io/crates/orx-linked-list).
+//! * It is important for **concurrent** programs as it eliminates safety concerns related with elements implicitly carried to different memory locations. This helps reducing and dealing with the complexity of concurrency, and leads to efficient concurrent data structures. See [`ConcurrentIter`](https://crates.io/crates/orx-concurrent-iter), [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) or [`ConcurrentOrderedBag`](https://crates.io/crates/orx-concurrent-ordered-bag) for such concurrent data structures which are conveniently built on the pinned element guarantees of pinned vectors.
 //! * It is essential in allowing an **immutable push** vector; i.e., [`ImpVec`](https://crates.io/crates/orx-imp-vec). This is a very useful operation when the desired collection is a bag or a container of things, rather than having a collective meaning. In such cases, `ImpVec` allows avoiding certain borrow checker complexities, heap allocations and wide pointers such as `Box` or `Rc` or etc.
-//! * It is important for **concurrent** programs since it eliminates safety concerns related with elements implicitly carried to different memory locations. This helps reducing and dealing with the complexity of concurrency. [`ConcurrentBag`](https://crates.io/crates/orx-concurrent-bag) is a very simplistic and efficient concurrent data structure built on top of pinned vector guarantees.
 //!
 //! ## B. Comparison with `SplitVec`
 //!
@@ -19,7 +19,7 @@
 //!
 //! | **`FixedVec`**                                                               | **`SplitVec`**                                                                   |
 //! |------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-//! | Implements `PinnedVec` => can be wrapped by an `ImpVec` or `SelfRefCol` or `ConcurrentBag`. | Implements `PinnedVec` => can as well be wrapped by them.         |
+//! | Implements `PinnedVec` => can be wrapped by an `ImpVec` or `SelfRefCol` or `ConcurrentBag`, etc. | Implements `PinnedVec` => can as well be wrapped by them.         |
 //! | Requires exact capacity to be known while creating.                          | Can be created with any level of prior information about required capacity.      |
 //! | Cannot grow beyond capacity; panics when `push` is called at capacity.       | Can grow dynamically. Further, it provides control on how it must grow. |
 //! | It is just a wrapper around `std::vec::Vec`; hence, has equivalent performance. | Performance-optimized built-in growth strategies also have `std::vec::Vec` equivalent performance. |
@@ -124,6 +124,7 @@
 
 mod common_traits;
 mod fixed_vec;
+mod helpers;
 mod pinned_vec;
 
 /// Common relevant traits, structs, enums.


### PR DESCRIPTION
Two slice returning methods are introduced. These methods are important in performant critical applications which allows to directly benefit from slice optimizations.
* `fn slices(&self, range: R)` returns an iterator of slices representing a given range of the vector.
* `fn slices_mut(&mut self, range: R)` returns a mutable iterator of slices representing a given range of the vector.

A concurrently safe growth method method `grow_and_initialize` is introduced. This methods performs capacity growth and length growth at the same time making sure that all elements are initialized with valid values.

Also, `into_inner` is implemented to convert fixed vector into the underlying standard vector.

Test methods are extended accordingly.