### PR TITLE
concurrency-support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-fixed-vec"
-version = "2.12.0"
+version = "3.0.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with fixed capacity and pinned elements."
@@ -10,7 +10,8 @@ keywords = ["vec", "pinned", "array", "split", "fixed"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pinned-vec = "2.12"
+orx-pseudo-default = "1.0"
+orx-pinned-vec = "3.0"
 
 [[bench]]
 name = "random_access"

--- a/src/concurrent_pinned_vec.rs
+++ b/src/concurrent_pinned_vec.rs
@@ -1,0 +1,130 @@
+use crate::{
+    helpers::range::{range_end, range_start},
+    FixedVec,
+};
+use orx_pinned_vec::{ConcurrentPinnedVec, PinnedVecGrowthError};
+use std::cmp::Ordering;
+
+/// Concurrent wrapper ([`orx_pinned_vec::ConcurrentPinnedVec`]) for the `FixedVec`.
+pub struct ConcurrentFixedVec<T> {
+    data: Vec<T>,
+    ptr: *mut T,
+    fixed_capacity: usize,
+}
+
+impl<T> From<FixedVec<T>> for ConcurrentFixedVec<T> {
+    fn from(value: FixedVec<T>) -> Self {
+        let mut data = value.data;
+        let fixed_capacity = data.capacity();
+        unsafe { data.set_len(fixed_capacity) };
+        let ptr = data.as_mut_ptr();
+        Self {
+            data,
+            ptr,
+            fixed_capacity,
+        }
+    }
+}
+
+impl<T> ConcurrentPinnedVec<T> for ConcurrentFixedVec<T> {
+    type P = FixedVec<T>;
+
+    unsafe fn into_inner(mut self, len: usize) -> Self::P {
+        unsafe { self.data.set_len(len) };
+        self.data.into()
+    }
+
+    fn capacity(&self) -> usize {
+        self.fixed_capacity
+    }
+
+    fn max_capacity(&self) -> usize {
+        self.fixed_capacity
+    }
+
+    fn grow_to(&self, new_capacity: usize) -> Result<usize, orx_pinned_vec::PinnedVecGrowthError> {
+        match new_capacity <= self.fixed_capacity {
+            true => Ok(self.fixed_capacity),
+            false => Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned),
+        }
+    }
+
+    unsafe fn slices_mut<R: std::ops::RangeBounds<usize>>(
+        &self,
+        range: R,
+    ) -> <Self::P as orx_pinned_vec::PinnedVec<T>>::SliceMutIter<'_> {
+        let a = range_start(&range);
+        let b = range_end(&range, self.fixed_capacity);
+
+        match b.saturating_sub(a) {
+            0 => Some(&mut []),
+            _ => match (a.cmp(&self.fixed_capacity), b.cmp(&self.fixed_capacity)) {
+                (Ordering::Equal | Ordering::Greater, _) => None,
+                (_, Ordering::Greater) => None,
+                _ => {
+                    let p = self.ptr.add(a);
+                    let slice = unsafe { std::slice::from_raw_parts_mut(p, b - a) };
+                    Some(slice)
+                }
+            },
+        }
+    }
+
+    unsafe fn iter<'a>(&'a self, len: usize) -> impl Iterator<Item = &'a T> + 'a
+    where
+        T: 'a,
+    {
+        let p = self.data.as_ptr();
+        let slice = std::slice::from_raw_parts(p, len);
+        slice.iter()
+    }
+
+    unsafe fn iter_mut<'a>(&'a mut self, len: usize) -> impl Iterator<Item = &'a mut T> + 'a
+    where
+        T: 'a,
+    {
+        let p = self.data.as_mut_ptr();
+        let slice = std::slice::from_raw_parts_mut(p, len);
+        slice.iter_mut()
+    }
+
+    unsafe fn set_pinned_vec_len(&mut self, len: usize) {
+        self.data.set_len(len);
+    }
+
+    unsafe fn get(&self, index: usize) -> Option<&T> {
+        match index < self.fixed_capacity {
+            true => Some(&*self.ptr.add(index)),
+            false => None,
+        }
+    }
+
+    unsafe fn get_mut(&mut self, index: usize) -> Option<&mut T> {
+        match index < self.capacity() {
+            true => Some(&mut self.data[index]),
+            false => None,
+        }
+    }
+
+    unsafe fn get_ptr_mut(&self, index: usize) -> *mut T {
+        assert!(index < self.fixed_capacity);
+        self.ptr.add(index)
+    }
+
+    unsafe fn reserve_maximum_concurrent_capacity(
+        &mut self,
+        _: usize,
+        new_maximum_capacity: usize,
+    ) -> usize {
+        let additional = new_maximum_capacity.saturating_sub(self.fixed_capacity);
+        self.data.reserve(additional);
+        self.fixed_capacity = self.data.capacity();
+        self.data.set_len(self.fixed_capacity);
+        self.fixed_capacity
+    }
+
+    unsafe fn clear(&mut self, prior_len: usize) {
+        self.set_pinned_vec_len(prior_len);
+        self.data.clear()
+    }
+}

--- a/src/helpers/range.rs
+++ b/src/helpers/range.rs
@@ -1,5 +1,6 @@
 use std::ops::RangeBounds;
 
+#[inline]
 pub(crate) fn range_start<R: RangeBounds<usize>>(range: &R) -> usize {
     match range.start_bound() {
         std::ops::Bound::Excluded(x) => x + 1,
@@ -7,6 +8,7 @@ pub(crate) fn range_start<R: RangeBounds<usize>>(range: &R) -> usize {
         std::ops::Bound::Unbounded => 0,
     }
 }
+#[inline]
 pub(crate) fn range_end<R: RangeBounds<usize>>(range: &R, vec_len: usize) -> usize {
     match range.end_bound() {
         std::ops::Bound::Excluded(x) => *x,

--- a/src/into_concurrent_pinned_vec.rs
+++ b/src/into_concurrent_pinned_vec.rs
@@ -1,0 +1,10 @@
+use crate::{ConcurrentFixedVec, FixedVec};
+use orx_pinned_vec::IntoConcurrentPinnedVec;
+
+impl<T> IntoConcurrentPinnedVec<T> for FixedVec<T> {
+    type ConPinnedVec = ConcurrentFixedVec<T>;
+
+    fn into_concurrent(self) -> Self::ConPinnedVec {
+        self.into()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,12 +123,17 @@
 )]
 
 mod common_traits;
+mod concurrent_pinned_vec;
 mod fixed_vec;
 mod helpers;
+mod into_concurrent_pinned_vec;
 mod pinned_vec;
 
 /// Common relevant traits, structs, enums.
 pub mod prelude;
 
+pub use concurrent_pinned_vec::ConcurrentFixedVec;
 pub use fixed_vec::FixedVec;
-pub use orx_pinned_vec::{CapacityState, PinnedVec, PinnedVecGrowthError};
+pub use orx_pinned_vec::{
+    ConcurrentPinnedVec, IntoConcurrentPinnedVec, PinnedVec, PinnedVecGrowthError,
+};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,2 +1,4 @@
 pub use crate::FixedVec;
-pub use orx_pinned_vec::{CapacityState, PinnedVec, PinnedVecGrowthError};
+pub use orx_pinned_vec::{
+    ConcurrentPinnedVec, IntoConcurrentPinnedVec, PinnedVec, PinnedVecGrowthError,
+};


### PR DESCRIPTION
# Support for Concurrency

In version 2, PinnedVec grew with new methods to support concurrent data structures. However, this caused problems since these exposed methods were often unsafe, and further, they were not directly useful for the pinned vector consumers except for concurrent data structures wrapping a pinned vector. Furthermore, they are alien to a regular vector interface that we are used to using.

In version 3, a second trait called `ConcurrentPinnedVec` is defined. All useful methods related with concurrent programming are moved to this trait. This trait has an associated type defining the underlying pinned vector type. It can be turned into the pinned vector.

Finally, `IntoConcurrentPinnedVec` trait is defined. A pinned vector implementing this trait can be turned into a `ConcurrentPinnedVec`. As explained above, it can be converted back to the pinned vector.

This bi-directional transformation allows to wrap pinned vector to have concurrent support, and unwrap whenever concurrency is not required anymore.

An important advantage of this approach is that it allowed to clean up the `PinnedVec` api from unsafe and alien concurrency related methods.

# Also

Tests using clock are revised so that currently pinned vector tests are **miri safe**.

`PseudoDefault` is required for all pinned vectors. Note that a `FixedVec` cannot implement a `Default`, but as any type, it can implement a pseudo-default, which is also required for concurrent wrappers.