### PR TITLE
fill with methods to enable initialized growth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-fixed-vec"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with fixed capacity and pinned elements."
@@ -10,8 +10,8 @@ keywords = ["vec", "pinned", "array", "split", "fixed"]
 categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
-orx-pseudo-default = "1.2.0"
-orx-pinned-vec = "3.2.0"
+orx-pinned-vec = "3.3"
+orx-pseudo-default = "1.2"
 
 [[bench]]
 name = "random_access"

--- a/src/into_concurrent_pinned_vec.rs
+++ b/src/into_concurrent_pinned_vec.rs
@@ -7,4 +7,15 @@ impl<T> IntoConcurrentPinnedVec<T> for FixedVec<T> {
     fn into_concurrent(self) -> Self::ConPinnedVec {
         self.into()
     }
+
+    fn into_concurrent_filled_with<F>(mut self, fill_with: F) -> Self::ConPinnedVec
+    where
+        F: Fn() -> T,
+    {
+        let (len, capacity) = (self.data.len(), self.data.capacity());
+        for _ in len..capacity {
+            self.data.push(fill_with());
+        }
+        self.into()
+    }
 }

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -377,14 +377,14 @@ mod tests {
 
     #[test]
     fn pinned_vec_exact_capacity() {
-        for cap in [0, 10, 124, 5421, 89746] {
+        for cap in [0, 124, 5421] {
             test_pinned_vec(FixedVec::new(cap), cap);
         }
     }
 
     #[test]
     fn pinned_vec_loose_capacity() {
-        for cap in [0, 10, 124, 5421] {
+        for cap in [0, 124, 5421] {
             test_pinned_vec(FixedVec::new(cap * 2), cap);
         }
     }


### PR DESCRIPTION
`into_concurrent_filled_with` and `grow_to_and_fill_with` methods are implemented to enable data structures which always have an initialized and valid state.