### PR TITLE
concurrent clone and fill

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
 orx-pseudo-default = "1.4"
-orx-pinned-vec = { path = "../orx-pinned-vec" }
+orx-pinned-vec = "3.6"
 
 [[bench]]
 name = "random_access"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-fixed-vec"
-version = "3.5.0"
+version = "3.6.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with fixed capacity and pinned elements."
@@ -11,7 +11,7 @@ categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
 orx-pseudo-default = "1.4"
-orx-pinned-vec = "3.5"
+orx-pinned-vec = { path = "../orx-pinned-vec" }
 
 [[bench]]
 name = "random_access"

--- a/src/fixed_vec.rs
+++ b/src/fixed_vec.rs
@@ -128,8 +128,8 @@ impl<T> FixedVec<T> {
 }
 
 impl<T> From<Vec<T>> for FixedVec<T> {
-    fn from(value: Vec<T>) -> Self {
-        Self { data: value }
+    fn from(data: Vec<T>) -> Self {
+        Self { data }
     }
 }
 


### PR DESCRIPTION
* clone_with_len is required for thread safe cloning of data.
* fill_with, on the other hand, is required for data structures that needs to be gap-free all the time.