### PR TITLE
reserve initiated capacity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-fixed-vec"
-version = "3.6.0"
+version = "3.7.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with fixed capacity and pinned elements."
@@ -11,7 +11,7 @@ categories = ["data-structures", "rust-patterns"]
 
 [dependencies]
 orx-pseudo-default = "1.4"
-orx-pinned-vec = "3.6"
+orx-pinned-vec = "3.7"
 
 [[bench]]
 name = "random_access"

--- a/src/concurrent_pinned_vec.rs
+++ b/src/concurrent_pinned_vec.rs
@@ -3,13 +3,13 @@ use crate::{
     FixedVec,
 };
 use orx_pinned_vec::{ConcurrentPinnedVec, PinnedVecGrowthError};
-use std::{cell::UnsafeCell, cmp::Ordering, fmt::Debug};
+use std::{cmp::Ordering, fmt::Debug};
 
 /// Concurrent wrapper ([`orx_pinned_vec::ConcurrentPinnedVec`]) for the `FixedVec`.
 pub struct ConcurrentFixedVec<T> {
     data: Vec<T>,
     ptr: *const T,
-    current_capacity: UnsafeCell<usize>,
+    current_capacity: usize,
 }
 
 impl<T> Debug for ConcurrentFixedVec<T> {
@@ -29,7 +29,7 @@ impl<T> From<FixedVec<T>> for ConcurrentFixedVec<T> {
         Self {
             data,
             ptr,
-            current_capacity: current_capacity.into(),
+            current_capacity,
         }
     }
 }
@@ -55,54 +55,31 @@ impl<T> ConcurrentPinnedVec<T> for ConcurrentFixedVec<T> {
     }
 
     fn capacity(&self) -> usize {
-        let x = self.current_capacity.get();
-        unsafe { *x }
+        self.current_capacity
     }
 
     fn max_capacity(&self) -> usize {
-        self.data.capacity()
+        self.current_capacity
     }
 
     fn grow_to(&self, new_capacity: usize) -> Result<usize, PinnedVecGrowthError> {
         match new_capacity <= self.capacity() {
             true => Ok(self.capacity()),
-            false => match new_capacity <= self.max_capacity() {
-                true => {
-                    let c = self.current_capacity.get();
-                    unsafe { *c = self.max_capacity() };
-                    Ok(self.capacity())
-                }
-                false => Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned),
-            },
+            false => Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned),
         }
     }
 
     fn grow_to_and_fill_with<F>(
         &self,
         new_capacity: usize,
-        fill_with: F,
+        _: F,
     ) -> Result<usize, PinnedVecGrowthError>
     where
         F: Fn() -> T,
     {
-        let current_capacity = self.capacity();
-        match new_capacity <= current_capacity {
-            true => Ok(current_capacity),
-            false => match new_capacity <= self.max_capacity() {
-                true => {
-                    let c = self.current_capacity.get();
-                    unsafe { *c = self.max_capacity() };
-
-                    let new_capacity = self.capacity();
-
-                    for i in current_capacity..new_capacity {
-                        unsafe { *self.get_ptr_mut(i) = fill_with() };
-                    }
-
-                    Ok(new_capacity)
-                }
-                false => Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned),
-            },
+        match new_capacity <= self.capacity() {
+            true => Ok(self.capacity()),
+            false => Err(PinnedVecGrowthError::FailedToGrowWhileKeepingElementsPinned),
         }
     }
 
@@ -207,9 +184,32 @@ impl<T> ConcurrentPinnedVec<T> for ConcurrentFixedVec<T> {
         self.data.reserve(additional);
 
         let new_capacity = self.data.capacity();
-        self.current_capacity = new_capacity.into();
+        self.current_capacity = new_capacity;
 
         new_capacity
+    }
+
+    unsafe fn reserve_maximum_concurrent_capacity_fill_with<F>(
+        &mut self,
+        current_len: usize,
+        new_maximum_capacity: usize,
+        fill_with: F,
+    ) -> usize
+    where
+        F: Fn() -> T,
+    {
+        let additional = new_maximum_capacity.saturating_sub(self.capacity());
+        self.data.reserve(additional);
+
+        self.current_capacity = self.data.capacity();
+
+        self.data.set_len(current_len);
+
+        for _ in current_len..self.current_capacity {
+            self.data.push(fill_with());
+        }
+
+        self.current_capacity
     }
 
     unsafe fn clear(&mut self, prior_len: usize) {

--- a/tests/con_fixed_vec.rs
+++ b/tests/con_fixed_vec.rs
@@ -1,0 +1,67 @@
+use orx_fixed_vec::*;
+
+#[test]
+fn reserve() {
+    let vec = FixedVec::<String>::new(42);
+
+    let mut con_vec = vec.into_concurrent();
+
+    unsafe { con_vec.get_ptr_mut(0).write("first".to_string()) };
+
+    assert_eq!(con_vec.capacity(), 42);
+    assert_eq!(con_vec.max_capacity(), 42);
+
+    unsafe { con_vec.reserve_maximum_concurrent_capacity(0, 74) };
+    let new_capacity = con_vec.capacity();
+    assert!(new_capacity >= 74);
+    assert_eq!(con_vec.max_capacity(), new_capacity);
+
+    let vec = unsafe { con_vec.into_inner(1) };
+
+    assert_eq!(vec.len(), 1);
+    assert_eq!(vec.capacity(), new_capacity);
+    assert_eq!(&vec[0], &"first".to_string());
+}
+
+#[test]
+fn into_concurrent_fill_with() {
+    let vec = FixedVec::<String>::new(42);
+    let con_vec = vec.into_concurrent_filled_with(|| "x".to_string());
+    let vec = unsafe { con_vec.into_inner(42) };
+    assert_eq!(vec, (0..42).map(|_| "x".to_string()).collect::<Vec<_>>());
+
+    let mut vec = FixedVec::<String>::new(42);
+    vec.push("y".to_string());
+    let con_vec = vec.into_concurrent_filled_with(|| "x".to_string());
+    let vec = unsafe { con_vec.into_inner(42) };
+    assert_eq!(&vec[0], &"y".to_string());
+    assert_eq!(
+        vec[1..],
+        (1..42).map(|_| "x".to_string()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn reserve_fill_with() {
+    let vec = FixedVec::<String>::new(42);
+
+    let mut con_vec = vec.into_concurrent_filled_with(|| "x".to_string());
+
+    unsafe { con_vec.reserve_maximum_concurrent_capacity_fill_with(42, 74, || "y".to_string()) };
+    let new_capacity = con_vec.capacity();
+    assert!(new_capacity >= 74);
+    assert_eq!(con_vec.max_capacity(), new_capacity);
+
+    let vec = unsafe { con_vec.into_inner(new_capacity) };
+
+    assert_eq!(
+        vec[0..42],
+        (0..42).map(|_| "x".to_string()).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        vec[42..],
+        (42..new_capacity)
+            .map(|_| "y".to_string())
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
* `ConcurrentFixedVec` is simplified by removing the UnsafeCell wrapper around capacity.
* This has been available due to the new required concurrent pinned vector method `reserve_maximum_concurrent_capacity_fill_with`.
* Tests on reserving maximum capacity are extended.

Fixes #33