### PR TITLE
support-for-self-referential-collections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-fixed-vec"
-version = "3.8.0"
+version = "3.9.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient constant access time vector with fixed capacity and pinned elements."
@@ -11,7 +11,7 @@ categories = ["data-structures", "rust-patterns", "no-std"]
 
 [dependencies]
 orx-pseudo-default = { version = "1.4", default-features = false }
-orx-pinned-vec = "3.8"
+orx-pinned-vec = "3.9"
 
 
 [[bench]]

--- a/src/fixed_vec.rs
+++ b/src/fixed_vec.rs
@@ -10,10 +10,10 @@ use alloc::vec::Vec;
 ///     * `FixedVec<T>` implements [`PinnedVec<T>`](https://crates.io/crates/orx-pinned-vec) for any `T`;
 ///     * `FixedVec<T>` implements `PinnedVecSimple<T>` for `T: NotSelfRefVecItem`;
 ///     * Memory location of an item added to the fixed vector will never change
-/// unless the vector is dropped or cleared.
+///       unless the vector is dropped or cleared.
 ///     * This allows the fixed vec to be converted into an [`ImpVec`](https://crates.io/crates/orx-imp-vec)
-/// to enable immutable-push operations which allows for
-/// convenient, efficient and safe implementations of self-referencing data structures.
+///       to enable immutable-push operations which allows for
+///       convenient, efficient and safe implementations of self-referencing data structures.
 pub struct FixedVec<T> {
     pub(crate) data: Vec<T>,
 }


### PR DESCRIPTION
The following methods are implemented:
* index_of_ptr
* push_get_ptr
* iter_ptr
* iter_ptr_rev
* contains_ptr
* get_ptr