### PR TITLE
Collection and concurrency support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain: ["stable"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install toolchain
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.toolchain }}
+
+    - name: Install 32bit target
+      run: rustup target add i686-unknown-linux-musl
+    - name: Install wasm target
+      run: rustup target add wasm32v1-none
+    - name: Install miri
+      run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu miri
+    - name: Install no-std-check
+      run: cargo install cargo-no-std-check
+      
+    - name: Build
+      run: cargo build --verbose
+    - name: Build-32bit
+      run: cargo build --verbose --target i686-unknown-linux-musl
+    - name: Build-wasm
+      run: cargo build --verbose --target wasm32v1-none
+
+    - name: Test
+      run: cargo test --verbose
+    - name: Test-32bit
+      run: cargo test --verbose --target i686-unknown-linux-musl
+    - name: Check-wasm
+      run: cargo check --verbose --target wasm32v1-none
+
+    - name: Clippy
+      run: cargo clippy -- -D warnings --verbose
+
+    - name: Miri
+      run: cargo +nightly miri test --verbose
+
+    - name: NoStd
+      run: cargo +nightly no-std-check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ harness = false
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
-rand = "0.8"
-rand_chacha = "0.3"
+rand = "0.9"
+rand_chacha = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "orx-fixed-vec"
-version = "3.15.0"
-edition = "2021"
+version = "4.0.0"
+edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient fixed capacity vector with pinned element guarantees."
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["data-structures", "rust-patterns", "no-std"]
 [dependencies]
 orx-iterable = { version = "1.2.0", default-features = false }
 orx-pseudo-default = { version = "2.0.0", default-features = false }
-orx-pinned-vec = "3.15"
+orx-pinned-vec = { path = "../orx-pinned-vec" }
 
 [[bench]]
 name = "random_access"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-fixed-vec"
-version = "4.0.0"
+version = "3.16.0"
 edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "An efficient fixed capacity vector with pinned element guarantees."
@@ -10,9 +10,9 @@ keywords = ["vec", "pinned", "array", "split", "fixed"]
 categories = ["data-structures", "rust-patterns", "no-std"]
 
 [dependencies]
-orx-iterable = { version = "1.2.0", default-features = false }
-orx-pseudo-default = { version = "2.0.0", default-features = false }
-orx-pinned-vec = { path = "../orx-pinned-vec" }
+orx-iterable = { version = "1.3.0", default-features = false }
+orx-pseudo-default = { version = "2.1.0", default-features = false }
+orx-pinned-vec = { version = "3.16.0", default-features = false }
 
 [[bench]]
 name = "random_access"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ An efficient fixed capacity vector with pinned element guarantees.
 
 A **FixedVec** implements [`PinnedVec`](https://crates.io/crates/orx-pinned-vec); you may read the detailed information about [pinned element guarantees](https://docs.rs/orx-pinned-vec/latest/orx_pinned_vec/#pinned-elements-guarantees) and why they are useful in the [motivation-and-examples](https://docs.rs/orx-pinned-vec/latest/orx_pinned_vec/#motivation--examples) section. In brief, a pinned vector does not allow implicit changes in memory locations of its elements; such as moving the entire vector to another memory location due to additional capacity requirement.
 
+> This crate is **no-std** by default.
+
 ## Features
 
 A fixed vec is simply a wrapper around the standard vector with the following two key differences:

--- a/benches/grow.rs
+++ b/benches/grow.rs
@@ -1,6 +1,6 @@
 use criterion::{
-    black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId,
-    Criterion,
+    BenchmarkGroup, BenchmarkId, Criterion, black_box, criterion_group, criterion_main,
+    measurement::WallTime,
 };
 use orx_fixed_vec::prelude::*;
 

--- a/benches/random_access.rs
+++ b/benches/random_access.rs
@@ -1,6 +1,6 @@
 use criterion::{
-    black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId,
-    Criterion,
+    BenchmarkGroup, BenchmarkId, Criterion, black_box, criterion_group, criterion_main,
+    measurement::WallTime,
 };
 use orx_fixed_vec::prelude::*;
 use rand::*;
@@ -10,7 +10,7 @@ fn get_indices(n: usize) -> Vec<usize> {
     let mut rng = ChaCha8Rng::seed_from_u64(7541);
     let mut vec = Vec::with_capacity(n);
     for _ in 0..n {
-        vec.push(rng.gen_range(0..n));
+        vec.push(rng.random_range(0..n));
     }
     vec
 }

--- a/benches/serial_access.rs
+++ b/benches/serial_access.rs
@@ -1,6 +1,6 @@
 use criterion::{
-    black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId,
-    Criterion,
+    BenchmarkGroup, BenchmarkId, Criterion, black_box, criterion_group, criterion_main,
+    measurement::WallTime,
 };
 use orx_fixed_vec::prelude::*;
 
@@ -56,8 +56,8 @@ fn test_for_type<T: Default + PartialEq + std::fmt::Debug>(
         let treatment = format!("n={},elem-type=[u64;{}]", n, num_u64s);
 
         group.bench_with_input(BenchmarkId::new("std_vec", &treatment), n, |b, _| {
-            let stdvec = std_vec_with_capacity(black_box(*n), value);
-            b.iter(|| calc(black_box(add), black_box(&stdvec)))
+            let std_vec = std_vec_with_capacity(black_box(*n), value);
+            b.iter(|| calc(black_box(add), black_box(&std_vec)))
         });
 
         group.bench_with_input(BenchmarkId::new("fixed_vec", &treatment), n, |b, _| {

--- a/src/concurrent_pinned_vec.rs
+++ b/src/concurrent_pinned_vec.rs
@@ -39,6 +39,18 @@ impl<T> From<FixedVec<T>> for ConcurrentFixedVec<T> {
 impl<T> ConcurrentPinnedVec<T> for ConcurrentFixedVec<T> {
     type P = FixedVec<T>;
 
+    type SliceIter<'a>
+        = Option<&'a [T]>
+    where
+        T: 'a,
+        Self: 'a;
+
+    type SliceMutIter<'a>
+        = Option<&'a mut [T]>
+    where
+        T: 'a,
+        Self: 'a;
+
     unsafe fn into_inner(mut self, len: usize) -> Self::P {
         unsafe { self.data.set_len(len) };
         self.data.into()

--- a/src/concurrent_pinned_vec.rs
+++ b/src/concurrent_pinned_vec.rs
@@ -1,6 +1,6 @@
 use crate::{
-    helpers::range::{range_end, range_start},
     FixedVec,
+    helpers::range::{range_end, range_start},
 };
 use alloc::vec::Vec;
 use core::cmp::Ordering;
@@ -140,7 +140,7 @@ impl<T> ConcurrentPinnedVec<T> for ConcurrentFixedVec<T> {
                 (Ordering::Equal | Ordering::Greater, _) => None,
                 (_, Ordering::Greater) => None,
                 _ => {
-                    let p = self.ptr.add(a);
+                    let p = unsafe { self.ptr.add(a) };
                     let slice = unsafe { core::slice::from_raw_parts_mut(p as *mut T, b - a) };
                     Some(slice)
                 }
@@ -153,7 +153,7 @@ impl<T> ConcurrentPinnedVec<T> for ConcurrentFixedVec<T> {
         T: 'a,
     {
         let p = self.data.as_ptr();
-        let slice = core::slice::from_raw_parts(p, len);
+        let slice = unsafe { core::slice::from_raw_parts(p, len) };
         slice.iter()
     }
 
@@ -166,8 +166,8 @@ impl<T> ConcurrentPinnedVec<T> for ConcurrentFixedVec<T> {
     {
         let [a, b] = orx_pinned_vec::utils::slice::vec_range_limits(&range, None);
         let len = b - a;
-        let p = self.data.as_ptr().add(a);
-        let slice = core::slice::from_raw_parts(p, len);
+        let p = unsafe { self.data.as_ptr().add(a) };
+        let slice = unsafe { core::slice::from_raw_parts(p, len) };
         slice.iter()
     }
 
@@ -176,17 +176,17 @@ impl<T> ConcurrentPinnedVec<T> for ConcurrentFixedVec<T> {
         T: 'a,
     {
         let p = self.data.as_mut_ptr();
-        let slice = core::slice::from_raw_parts_mut(p, len);
+        let slice = unsafe { core::slice::from_raw_parts_mut(p, len) };
         slice.iter_mut()
     }
 
     unsafe fn set_pinned_vec_len(&mut self, len: usize) {
-        self.data.set_len(len);
+        unsafe { self.data.set_len(len) };
     }
 
     unsafe fn get(&self, index: usize) -> Option<&T> {
         match index < self.capacity() {
-            true => Some(&*self.ptr.add(index)),
+            true => Some(unsafe { &*self.ptr.add(index) }),
             false => None,
         }
     }
@@ -200,7 +200,7 @@ impl<T> ConcurrentPinnedVec<T> for ConcurrentFixedVec<T> {
 
     unsafe fn get_ptr_mut(&self, index: usize) -> *mut T {
         assert!(index < self.capacity());
-        self.ptr.add(index) as *mut T
+        unsafe { self.ptr.add(index) as *mut T }
     }
 
     unsafe fn reserve_maximum_concurrent_capacity(
@@ -231,7 +231,7 @@ impl<T> ConcurrentPinnedVec<T> for ConcurrentFixedVec<T> {
 
         self.current_capacity = self.data.capacity();
 
-        self.data.set_len(current_len);
+        unsafe { self.data.set_len(current_len) };
 
         for _ in current_len..self.current_capacity {
             self.data.push(fill_with());
@@ -241,7 +241,7 @@ impl<T> ConcurrentPinnedVec<T> for ConcurrentFixedVec<T> {
     }
 
     unsafe fn clear(&mut self, prior_len: usize) {
-        self.set_pinned_vec_len(prior_len);
+        unsafe { self.set_pinned_vec_len(prior_len) };
         self.data.clear()
     }
 }

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -1,5 +1,5 @@
-use crate::helpers::range::{range_end, range_start};
 use crate::FixedVec;
+use crate::helpers::range::{range_end, range_start};
 use core::cmp::Ordering;
 use core::iter::Rev;
 use core::ops::RangeBounds;
@@ -222,12 +222,12 @@ impl<T> PinnedVec<T> for FixedVec<T> {
 
     #[inline(always)]
     unsafe fn get_unchecked(&self, index: usize) -> &T {
-        self.data.get_unchecked(index)
+        unsafe { self.data.get_unchecked(index) }
     }
 
     #[inline(always)]
     unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut T {
-        self.data.get_unchecked_mut(index)
+        unsafe { self.data.get_unchecked_mut(index) }
     }
 
     #[inline(always)]
@@ -242,12 +242,12 @@ impl<T> PinnedVec<T> for FixedVec<T> {
 
     #[inline(always)]
     unsafe fn first_unchecked(&self) -> &T {
-        self.data.get_unchecked(0)
+        unsafe { self.data.get_unchecked(0) }
     }
 
     #[inline(always)]
     unsafe fn last_unchecked(&self) -> &T {
-        self.data.get_unchecked(self.data.len() - 1)
+        unsafe { self.data.get_unchecked(self.data.len() - 1) }
     }
 
     #[inline(always)]
@@ -444,7 +444,7 @@ impl<T> PinnedVec<T> for FixedVec<T> {
 
     #[inline(always)]
     unsafe fn set_len(&mut self, new_len: usize) {
-        self.data.set_len(new_len)
+        unsafe { self.data.set_len(new_len) }
     }
 
     fn binary_search_by<F>(&self, f: F) -> Result<usize, usize>

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -22,16 +22,19 @@ impl<T> PinnedVec<T> for FixedVec<T> {
     where
         T: 'a,
         Self: 'a;
+
     type IterMutRev<'a>
         = Rev<core::slice::IterMut<'a, T>>
     where
         T: 'a,
         Self: 'a;
+
     type SliceIter<'a>
         = Option<&'a [T]>
     where
         T: 'a,
         Self: 'a;
+
     type SliceMutIter<'a>
         = Option<&'a mut [T]>
     where
@@ -395,6 +398,38 @@ impl<T> PinnedVec<T> for FixedVec<T> {
                 _ => Some(&mut self.data[a..b]),
             },
         }
+    }
+
+    fn iter_over<'a>(
+        &'a self,
+        range: impl RangeBounds<usize>,
+    ) -> impl ExactSizeIterator<Item = &'a T>
+    where
+        T: 'a,
+    {
+        use core::cmp::{max, min};
+
+        let len = PinnedVec::len(self);
+        let a = min(len, range_start(&range));
+        let b = max(a, min(len, range_end(&range, len)));
+
+        self.data[a..b].iter()
+    }
+
+    fn iter_mut_over<'a>(
+        &'a mut self,
+        range: impl RangeBounds<usize>,
+    ) -> impl ExactSizeIterator<Item = &'a mut T>
+    where
+        T: 'a,
+    {
+        use core::cmp::{max, min};
+
+        let len = PinnedVec::len(self);
+        let a = min(len, range_start(&range));
+        let b = max(a, min(len, range_end(&range, len)));
+
+        self.data[a..b].iter_mut()
     }
 
     #[inline(always)]

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -475,6 +475,10 @@ impl<T> PinnedVec<T> for FixedVec<T> {
     {
         self.data.sort_by_key(f)
     }
+
+    fn capacity_bound(&self) -> usize {
+        usize::MAX
+    }
 }
 
 #[cfg(test)]

--- a/src/pinned_vec.rs
+++ b/src/pinned_vec.rs
@@ -491,14 +491,24 @@ mod tests {
 
     #[test]
     fn pinned_vec_exact_capacity() {
-        for cap in [0, 124, 5421] {
+        #[cfg(not(miri))]
+        let capacities = [0, 124, 5421];
+        #[cfg(miri)]
+        let capacities = [0, 44];
+
+        for cap in capacities {
             test_pinned_vec(FixedVec::new(cap), cap);
         }
     }
 
     #[test]
     fn pinned_vec_loose_capacity() {
-        for cap in [0, 124, 5421] {
+        #[cfg(not(miri))]
+        let capacities = [0, 124, 5421];
+        #[cfg(miri)]
+        let capacities = [0, 44];
+
+        for cap in capacities {
             test_pinned_vec(FixedVec::new(cap * 2), cap);
         }
     }


### PR DESCRIPTION
Migration to edition2024.

SliceIter is defined.

`iter_over` and `iter_over_mut` methods are implemented as a generalization of creating slices from a vec.

CI action is added.

Documentation is updated for no-std.
